### PR TITLE
fix regex stateful bug and literal bug

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,7 @@ const list = () => {
 			return;
 		}
 
+		regex.lastIndex = 0;
 		let data = regex.exec(line.replace(/\s+/g, ' '));
 		if (data) {
 			let connection = new Connection(
@@ -66,5 +67,5 @@ exports.IsConnected = name => {
 
 exports.IsConnecting = name => {
 	let found = findByName(name);
-	return (found !== undefined && found.IsConnecting());
+	return (found !== undefined && found.isConnecting());
 }


### PR DESCRIPTION
[A JavaScript RegExp object is stateful](https://stackoverflow.com/questions/11477415/why-does-javascripts-regex-exec-not-always-return-the-same-value),so when there is more then one vpn connection in mac, the result is not what is expected.