### PR TITLE
Bump Alfy dependency to fix issue with Alfred 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "network"
   ],
   "dependencies": {
-    "alfy": "^0.6.0"
+    "alfy": "^0.9.1"
   },
   "devDependencies": {
     "alfy-test": "^0.3.0",


### PR DESCRIPTION
Apparently, Alfred 4 moved the preferences file, leading to the error described in https://github.com/stve/alfred-vpn/issues/2

This was fixed upstream in `0.9.1`: https://github.com/sindresorhus/alfy/releases/tag/v0.9.1